### PR TITLE
Support for params inside the request

### DIFF
--- a/router.ts
+++ b/router.ts
@@ -18,9 +18,7 @@ export class Route {
                 if (c === "/") {
                     if (currPathSegment.length < 1) {
                         // checks if this route was made by server or during a request loop
-                        if (handler) {
-                            throw `Invalid path ${path}. Each path segment should be seperated by exactly one slash /`;
-                        }
+                        throw `Invalid path ${path}. Each path segment should be seperated by exactly one slash /`;
                     }
                     else {
                         this.path_segments.push(currPathSegment);

--- a/router.ts
+++ b/router.ts
@@ -8,15 +8,15 @@ export class Route {
     constructor(path: string, handler: any) {
         this.path = path
         this.handler = handler
-        if(path[0] !== '/') {
+        if (path[0] !== '/') {
             throw `Invalid path ${path}. Paths should begin with a slash /`;
         }
         let currPathSegment = "";
-        for(var i = 0; i < path.length; i++) {
-            if(i > 0) {
+        for (var i = 0; i < path.length; i++) {
+            if (i > 0) {
                 let c = path[i];
-                if(c === "/") {
-                    if(currPathSegment.length < 1) {
+                if (c === "/") {
+                    if (currPathSegment.length < 1) {
                         throw `Invalid path ${path}. Each path segment should be seperated by exactly one slash /`;
                     }
                     else {
@@ -29,7 +29,7 @@ export class Route {
                 }
             }
         }
-        if(currPathSegment.length > 0) {
+        if (currPathSegment.length > 0) {
             this.path_segments.push(currPathSegment);
             currPathSegment = "";
         }
@@ -49,7 +49,7 @@ export class Router {
         console.log("Serving up some tasty routes")
         for await (const req of this.serve_instance) {
             let matched = false;
-            
+
             let requested = new Route(req.url, null)
             // Only match against routes with the same number of segments
             let routsWithSameCountOfSegments = this.routes.filter((route) => {
@@ -57,29 +57,29 @@ export class Router {
             })
             // Further filter my routes with exact matches or potential matches from slugs
             let possibleRoutes: Route[] = []
-            for(let rdx in routsWithSameCountOfSegments) {
+            for (let rdx in routsWithSameCountOfSegments) {
                 let route = routsWithSameCountOfSegments[rdx];
                 let routeDisqualified = false
                 let wildcard_count = 0;
                 let first_wildcard = -1;
-                for(var segment_idx = 0; segment_idx <  route.path_segments.length; segment_idx++) {
+                for (var segment_idx = 0; segment_idx < route.path_segments.length; segment_idx++) {
                     let route_segment = route.path_segments[segment_idx];
-                    if(route_segment[0] == ":") {
+                    if (route_segment[0] == ":") {
                         // This is a slug/wildcard so we can't filter it yet
-                        if(wildcard_count == 0) {
+                        if (wildcard_count == 0) {
                             first_wildcard = segment_idx
                         }
                         wildcard_count++
                     }
                     else {
-                        if(route_segment != requested.path_segments[segment_idx]) {
+                        if (route_segment != requested.path_segments[segment_idx]) {
                             // Non-matching route
                             routeDisqualified = true
                             break
                         }
                     }
                 }
-                if(!routeDisqualified) {
+                if (!routeDisqualified) {
                     possibleRoutes.push(route)
                 }
             }
@@ -87,13 +87,13 @@ export class Router {
             // and either exact matches or wildcards.
             // TODO: Sort on route insert, rather than on query
             let possibleRoutesSorted = possibleRoutes.sort((a, b) => {
-                for(var i=0;i<a.path_segments.length;i++) {
+                for (var i = 0; i < a.path_segments.length; i++) {
                     let psa = a.path_segments[i];
                     let psb = b.path_segments[i];
                     let a_is_wild = psa[0] === ":"
                     let b_is_wild = psb[0] === ":"
                     if (a_is_wild != b_is_wild) {
-                        if(a_is_wild) {
+                        if (a_is_wild) {
                             // b is the better choice bc it is more specific
                             return 1
                         }
@@ -107,14 +107,14 @@ export class Router {
                 return 0
             })
             console.log(`  ####  ${requested.path}  ####  `)
-            if(possibleRoutesSorted.length > 0) {
+            if (possibleRoutesSorted.length > 0) {
                 let selectedRoute = possibleRoutesSorted[0];
                 matched = true
                 // selectedRoute.describe_handler();
 
                 // So, this is actually the number of args in the callback, but if there's a mismatch from the params in the URL, then they just need to fix that at their call site
                 let numParams = selectedRoute.handler.length - 1;
-                if(numParams == 0) {
+                if (numParams == 0) {
                     selectedRoute.handler(req);
                 }
                 else {
@@ -123,15 +123,15 @@ export class Router {
                     // Find the indices of the slugs
                     let routeSlugs: string[] = []
                     let slugIndices: number[] = []
-                    for(var i = 0; i < selectedRoute.path_segments.length; i++) {
+                    for (var i = 0; i < selectedRoute.path_segments.length; i++) {
                         let path = selectedRoute.path_segments[i];
-                        if(path[0] === ":") {
+                        if (path[0] === ":") {
                             const sslug = path.substring(1, path.length);
                             routeSlugs.push(sslug);
                             slugIndices.push(i);
                         }
                     }
-                    for(var i = 0; i <= numParams; i++) {
+                    for (var i = 0; i <= numParams; i++) {
                         // args.push(requested.path_segments[slugIndices[i]])
                         let argKey = routeSlugs[i]
                         let argVal = requested.path_segments[slugIndices[i]]
@@ -141,7 +141,7 @@ export class Router {
                     selectedRoute.handler(req, argsMap);
                 }
             }
-            if(!matched) {
+            if (!matched) {
                 // Handle 404 when no match occurs
                 console.log(`404: ${req.url}`)
                 this.handle404(req)
@@ -154,7 +154,7 @@ export class Router {
     handle404default(req: ServerRequest) {
         req.respond({ body: `404 Not Found` })
     }
-    on(route: string, handler: (req: ServerRequest, query: Map<string, string>) => void)  {
+    on(route: string, handler: (req: ServerRequest, query: Map<string, string>) => void) {
         let newRoute = new Route(route, handler);
         this.routes.push(newRoute)
     }

--- a/tasty_tests.ts
+++ b/tasty_tests.ts
@@ -6,7 +6,7 @@ import {
     assertMatch,
     assertStrContains,
     assertThrowsAsync,
-  } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.42.0/testing/asserts.ts";
 const { Buffer, test } = Deno;
 
 

--- a/tasty_tests.ts
+++ b/tasty_tests.ts
@@ -41,6 +41,31 @@ test("Test that slug logic works as expected", async function (): Promise<void> 
         let f = query.get("f");
         req.respond({ body: `${e} ${f}` })
     });
+    router.on("/params", (req, query: Map<string, string>, params) => {
+        req.respond({
+            body: `${params.get("test")} ${params.get("test2")} ${params.get(
+                "bigtestquerythatsverybigandpropopablybiggerthanyouwouldthink"
+            )}`,
+        });
+    });
+
+    router.on("/params/level", (req, query: Map<string, string>, params) => {
+        req.respond({
+            body: `${params.get("test")} ${params.get("test2")} ${params.get(
+                "bigtestquerythatsverybigandpropopablybiggerthanyouwouldthink"
+            )}`,
+        });
+    });
+    router.on(
+        "/params-two-question",
+        (req, query: Map<string, string>, params) => {
+            req.respond({
+                body: `${params.get("a")}`,
+            });
+        }
+    );
+
+
     assertEquals(await (await fetch("http://localhost:8000/reversed/args/e1/f1")).text(), "e1 f1")
     assertEquals(await (await fetch("http://localhost:8000/ae/")).text(), "/a")
     assertEquals(await (await fetch("http://localhost:8000/ae/651")).text(), "/a2/651")
@@ -50,6 +75,13 @@ test("Test that slug logic works as expected", async function (): Promise<void> 
     assertEquals(await (await fetch("http://localhost:8000/slasher/")).text(), "slasher1")
     assertEquals(await (await fetch("http://localhost:8000/noslasher")).text(), "slasher2")
     assertEquals(await (await fetch("http://localhost:8000/noslasher/")).text(), "slasher2")
+    assertEquals(await (await fetch("http://localhost:8000/params?test=hello&test2=234&bigtestquerythatsverybigandpropopablybiggerthanyouwouldthink=c"))
+        .text(), "hello 234 c"
+    );
+    assertEquals(await (await fetch("http://localhost:8000/params-two-question??a=2")).text(), "2");
+    assertEquals(await (await fetch(`http://localhost:8000///params-two-question//??a=2`)).text(), "2");
+    assertEquals(await (await fetch("http://localhost:8000/params/level?test=hello&test2=xc8)_^%^&bigtestquerythatsverybigandpropopablybiggerthanyouwouldthink=1"))
+        .text(), "400 Bad Request");
     s.close();
 })
 


### PR DESCRIPTION
Added support for third argument in the handler function
allows to get params from the URL requested 
eg. param.get("x") to get params inside a request https://example.com?x=1